### PR TITLE
Added return types for functions

### DIFF
--- a/cli_impl/lpg_cli.c
+++ b/cli_impl/lpg_cli.c
@@ -118,6 +118,8 @@ static char const *describe_parse_error(parse_error_type const error)
         return "Expected comma";
     case parse_error_expected_lambda_body:
         return "Expected lambda body";
+    case parse_error_expected_return_type:
+        return "Expected return type";
     case parse_error_unknown_binary_operator:
         return "Unknown binary operator";
     }

--- a/syntax/lpg_expression.c
+++ b/syntax/lpg_expression.c
@@ -25,7 +25,10 @@ void lambda_free(lambda const *this)
     {
         deallocate(this->parameters);
     }
-    expression_deallocate(this->return_type);
+    if (this->return_type != NULL)
+    {
+        expression_deallocate(this->return_type);
+    }
     expression_deallocate(this->result);
 }
 

--- a/syntax/lpg_expression.c
+++ b/syntax/lpg_expression.c
@@ -9,9 +9,9 @@ void expression_deallocate(expression *this)
     deallocate(this);
 }
 
-lambda lambda_create(parameter *parameters, size_t parameter_count, expression *result)
+lambda lambda_create(parameter *parameters, size_t parameter_count, expression *return_type, expression *result)
 {
-    lambda const returning = {parameters, parameter_count, result};
+    lambda const returning = {parameters, parameter_count, return_type, result};
     return returning;
 }
 
@@ -25,6 +25,7 @@ void lambda_free(lambda const *this)
     {
         deallocate(this->parameters);
     }
+    expression_deallocate(this->return_type);
     expression_deallocate(this->result);
 }
 

--- a/syntax/lpg_expression.h
+++ b/syntax/lpg_expression.h
@@ -13,10 +13,11 @@ typedef struct lambda
 {
     parameter *parameters;
     size_t parameter_count;
+    expression *return_type;
     expression *result;
 } lambda;
 
-lambda lambda_create(parameter *parameters, size_t parameter_count, LPG_NON_NULL(expression *result));
+lambda lambda_create(parameter *parameters, size_t parameter_count, expression *return_type, expression *result);
 void lambda_free(LPG_NON_NULL(lambda const *this));
 bool lambda_equals(lambda const left, lambda const right);
 

--- a/syntax/lpg_parse_expression.c
+++ b/syntax/lpg_parse_expression.c
@@ -135,7 +135,7 @@ static expression_parser_result const expression_parser_result_failure = {
 static expression_parser_result parse_tuple(expression_parser *parser, size_t indentation);
 
 static expression_parser_result parse_returnable(expression_parser *const parser, size_t const indentation,
-                                                 bool const may_be_statement, bool const may_be_binary);
+                                                 bool const may_be_binary);
 
 static expression_parser_result parse_loop(expression_parser *parser, size_t indentation)
 {
@@ -321,7 +321,7 @@ static expression_parser_result parse_lambda(expression_parser *const parser, si
                 {
                     pop(parser);
                 }
-                expression_parser_result const type = parse_returnable(parser, indentation, false, false);
+                expression_parser_result const type = parse_returnable(parser, indentation, false);
                 result_type = expression_allocate(type.success);
                 if (!type.is_success)
                 {

--- a/syntax/lpg_parse_expression.h
+++ b/syntax/lpg_parse_expression.h
@@ -31,6 +31,7 @@ typedef enum parse_error_type
     parse_error_expected_element_name,
     parse_error_expected_identifier,
     parse_error_expected_lambda_body,
+    parse_error_expected_return_type,
     parse_error_unknown_binary_operator
 } parse_error_type;
 

--- a/syntax/lpg_save_expression.c
+++ b/syntax/lpg_save_expression.c
@@ -65,7 +65,8 @@ success_indicator save_expression(stream_writer const to, expression const *valu
             LPG_TRY(save_expression(to, param->type, whitespace));
         }
         LPG_TRY(stream_writer_write_string(to, ")"));
-        if(value->lambda.return_type != NULL){
+        if (value->lambda.return_type != NULL)
+        {
             LPG_TRY(stream_writer_write_string(to, ": "));
             LPG_TRY(save_expression(to, value->lambda.return_type, whitespace));
         }

--- a/syntax/lpg_save_expression.c
+++ b/syntax/lpg_save_expression.c
@@ -65,6 +65,10 @@ success_indicator save_expression(stream_writer const to, expression const *valu
             LPG_TRY(save_expression(to, param->type, whitespace));
         }
         LPG_TRY(stream_writer_write_string(to, ")"));
+        if(value->lambda.return_type != NULL){
+            LPG_TRY(stream_writer_write_string(to, ": "));
+            LPG_TRY(save_expression(to, value->lambda.return_type, whitespace));
+        }
         LPG_TRY(save_expression(to, value->lambda.result, add_space_or_newline(whitespace)));
         return success;
 

--- a/tests/test_parse_expression_success.c
+++ b/tests/test_parse_expression_success.c
@@ -101,14 +101,16 @@ static void test_lambdas()
         *result_expression = expression_from_integer_literal(
             integer_literal_expression_create(integer_create(0, 1), source_location_create(0, 4)));
 
-        expression *lambda_content = allocate(sizeof(*result_expression));
-        *lambda_content = expression_from_integer_literal(
+        expression *const elements = allocate_array(1, sizeof(*elements));
+        elements[0] = expression_from_integer_literal(
             integer_literal_expression_create(integer_create(0, 1), source_location_create(1, 4)));
+        test_successful_parse(
+            expression_from_lambda(lambda_create(
+                NULL, 0, NULL, expression_allocate(expression_from_sequence(sequence_create(elements, 1))))),
+            unicode_string_from_c_str("(): 1\n"
+                                      "    1"),
+            false);
 
-        test_successful_parse(expression_from_lambda(lambda_create(NULL, 0, result_expression, lambda_content)),
-                              unicode_string_from_c_str("(): 1\n"
-                                                        "    1"),
-                              false);
         expression_deallocate(result_expression);
     }
 

--- a/tests/test_parse_expression_success.c
+++ b/tests/test_parse_expression_success.c
@@ -91,16 +91,20 @@ void test_parse_expression_success(void)
 static void test_lambdas()
 {
     test_successful_parse(
-        expression_from_lambda(lambda_create(
-            NULL, 0, expression_allocate(expression_from_integer_literal(
-                         integer_literal_expression_create(integer_create(0, 1), source_location_create(0, 3)))))),
+        expression_from_lambda(lambda_create(NULL, 0, NULL, expression_allocate(expression_from_integer_literal(
+                integer_literal_expression_create(integer_create(0, 1), source_location_create(0, 3)))))),
         unicode_string_from_c_str("() 1"), false);
 
     test_successful_parse(
-        expression_from_lambda(lambda_create(
-            NULL, 0, expression_allocate(expression_from_lambda(lambda_create(
-                         NULL, 0, expression_allocate(expression_from_integer_literal(integer_literal_expression_create(
-                                      integer_create(0, 1), source_location_create(0, 6))))))))),
+        expression_from_lambda(lambda_create(NULL, 0, NULL, expression_allocate(expression_from_integer_literal(
+                integer_literal_expression_create(integer_create(0, 1), source_location_create(0, 21)))))),
+        unicode_string_from_c_str("(): integer(0, 1) => 1"), false);
+
+    test_successful_parse(
+        expression_from_lambda(lambda_create(NULL, 0, NULL, expression_allocate(
+                expression_from_lambda(lambda_create(NULL, 0, NULL, expression_allocate(
+                        expression_from_integer_literal(integer_literal_expression_create(
+                                integer_create(0, 1), source_location_create(0, 6))))))))),
         unicode_string_from_c_str("() () 1"), false);
 
     {
@@ -109,7 +113,8 @@ static void test_lambdas()
             integer_literal_expression_create(integer_create(0, 1), source_location_create(1, 4)));
         test_successful_parse(
             expression_from_lambda(
-                lambda_create(NULL, 0, expression_allocate(expression_from_sequence(sequence_create(elements, 1))))),
+                    lambda_create(NULL, 0, NULL,
+                                  expression_allocate(expression_from_sequence(sequence_create(elements, 1))))),
             unicode_string_from_c_str("()\n"
                                       "    1"),
             false);
@@ -125,8 +130,8 @@ static void test_lambdas()
                              expression_allocate(expression_from_identifier(identifier_expression_create(
                                  unicode_string_from_c_str("type"), source_location_create(0, 4)))));
         test_successful_parse(
-            expression_from_lambda(lambda_create(
-                parameters, 1, expression_allocate(expression_from_sequence(sequence_create(elements, 1))))),
+            expression_from_lambda(lambda_create(parameters, 1, NULL, expression_allocate(
+                    expression_from_sequence(sequence_create(elements, 1))))),
             unicode_string_from_c_str("(a: type)\n"
                                       "    1"),
             false);
@@ -146,8 +151,8 @@ static void test_lambdas()
                              expression_allocate(expression_from_identifier(identifier_expression_create(
                                  unicode_string_from_c_str("d"), source_location_create(0, 10)))));
         test_successful_parse(
-            expression_from_lambda(lambda_create(
-                parameters, 2, expression_allocate(expression_from_sequence(sequence_create(elements, 1))))),
+            expression_from_lambda(lambda_create(parameters, 2, NULL, expression_allocate(
+                    expression_from_sequence(sequence_create(elements, 1))))),
             unicode_string_from_c_str("(a: b, c: d)\n"
                                       "    1"),
             false);

--- a/tests/test_parse_expression_success.c
+++ b/tests/test_parse_expression_success.c
@@ -91,20 +91,33 @@ void test_parse_expression_success(void)
 static void test_lambdas()
 {
     test_successful_parse(
-        expression_from_lambda(lambda_create(NULL, 0, NULL, expression_allocate(expression_from_integer_literal(
-                integer_literal_expression_create(integer_create(0, 1), source_location_create(0, 3)))))),
+        expression_from_lambda(lambda_create(
+            NULL, 0, NULL, expression_allocate(expression_from_integer_literal(integer_literal_expression_create(
+                               integer_create(0, 1), source_location_create(0, 3)))))),
         unicode_string_from_c_str("() 1"), false);
 
-    test_successful_parse(
-        expression_from_lambda(lambda_create(NULL, 0, NULL, expression_allocate(expression_from_integer_literal(
-                integer_literal_expression_create(integer_create(0, 1), source_location_create(0, 21)))))),
-        unicode_string_from_c_str("(): integer(0, 1) => 1"), false);
+    {
+        expression *result_expression = allocate(sizeof(*result_expression));
+        *result_expression = expression_from_integer_literal(
+            integer_literal_expression_create(integer_create(0, 1), source_location_create(0, 4)));
+
+        expression *lambda_content = allocate(sizeof(*result_expression));
+        *lambda_content = expression_from_integer_literal(
+            integer_literal_expression_create(integer_create(0, 1), source_location_create(1, 4)));
+
+        test_successful_parse(expression_from_lambda(lambda_create(NULL, 0, result_expression, lambda_content)),
+                              unicode_string_from_c_str("(): 1\n"
+                                                        "    1"),
+                              false);
+        expression_deallocate(result_expression);
+    }
 
     test_successful_parse(
-        expression_from_lambda(lambda_create(NULL, 0, NULL, expression_allocate(
-                expression_from_lambda(lambda_create(NULL, 0, NULL, expression_allocate(
-                        expression_from_integer_literal(integer_literal_expression_create(
-                                integer_create(0, 1), source_location_create(0, 6))))))))),
+        expression_from_lambda(lambda_create(
+            NULL, 0, NULL,
+            expression_allocate(expression_from_lambda(lambda_create(
+                NULL, 0, NULL, expression_allocate(expression_from_integer_literal(integer_literal_expression_create(
+                                   integer_create(0, 1), source_location_create(0, 6))))))))),
         unicode_string_from_c_str("() () 1"), false);
 
     {
@@ -112,9 +125,8 @@ static void test_lambdas()
         elements[0] = expression_from_integer_literal(
             integer_literal_expression_create(integer_create(0, 1), source_location_create(1, 4)));
         test_successful_parse(
-            expression_from_lambda(
-                    lambda_create(NULL, 0, NULL,
-                                  expression_allocate(expression_from_sequence(sequence_create(elements, 1))))),
+            expression_from_lambda(lambda_create(
+                NULL, 0, NULL, expression_allocate(expression_from_sequence(sequence_create(elements, 1))))),
             unicode_string_from_c_str("()\n"
                                       "    1"),
             false);
@@ -130,8 +142,8 @@ static void test_lambdas()
                              expression_allocate(expression_from_identifier(identifier_expression_create(
                                  unicode_string_from_c_str("type"), source_location_create(0, 4)))));
         test_successful_parse(
-            expression_from_lambda(lambda_create(parameters, 1, NULL, expression_allocate(
-                    expression_from_sequence(sequence_create(elements, 1))))),
+            expression_from_lambda(lambda_create(
+                parameters, 1, NULL, expression_allocate(expression_from_sequence(sequence_create(elements, 1))))),
             unicode_string_from_c_str("(a: type)\n"
                                       "    1"),
             false);
@@ -151,8 +163,8 @@ static void test_lambdas()
                              expression_allocate(expression_from_identifier(identifier_expression_create(
                                  unicode_string_from_c_str("d"), source_location_create(0, 10)))));
         test_successful_parse(
-            expression_from_lambda(lambda_create(parameters, 2, NULL, expression_allocate(
-                    expression_from_sequence(sequence_create(elements, 1))))),
+            expression_from_lambda(lambda_create(
+                parameters, 2, NULL, expression_allocate(expression_from_sequence(sequence_create(elements, 1))))),
             unicode_string_from_c_str("(a: b, c: d)\n"
                                       "    1"),
             false);

--- a/tests/test_save_expression.c
+++ b/tests/test_save_expression.c
@@ -81,9 +81,9 @@ void test_save_expression(void)
                              expression_allocate(expression_from_identifier(identifier_expression_create(
                                  unicode_string_from_c_str("uint32"), source_location_create(0, 0)))));
         check_expression_rendering(
-            expression_from_lambda(lambda_create(
-                parameters, 1, expression_allocate(expression_from_integer_literal(integer_literal_expression_create(
-                                   integer_create(0, 1234), source_location_create(0, 0)))))),
+            expression_from_lambda(lambda_create(parameters, 1, NULL, expression_allocate(
+                    expression_from_integer_literal(integer_literal_expression_create(
+                            integer_create(0, 1234), source_location_create(0, 0)))))),
             "(a: uint32) 1234");
     }
 
@@ -216,8 +216,8 @@ void test_save_expression(void)
                                  unicode_string_from_c_str("uint32"), source_location_create(0, 0)))));
 
         check_expression_rendering(
-            expression_from_lambda(lambda_create(
-                parameters, 1, expression_allocate(expression_from_loop(sequence_create(outer_loop, 2))))),
+            expression_from_lambda(lambda_create(parameters, 1, NULL, expression_allocate(
+                    expression_from_loop(sequence_create(outer_loop, 2))))),
             "(a: uint32) loop\n"
             "    a == 123\n"
             "    loop\n"
@@ -236,9 +236,9 @@ void test_save_expression(void)
                                  unicode_string_from_c_str("string"), source_location_create(0, 0)))));
 
         check_expression_rendering(
-            expression_from_lambda(lambda_create(
-                parameters, 2, expression_allocate(expression_from_integer_literal(integer_literal_expression_create(
-                                   integer_create(0, 123), source_location_create(0, 0)))))),
+            expression_from_lambda(lambda_create(parameters, 2, NULL, expression_allocate(
+                    expression_from_integer_literal(integer_literal_expression_create(
+                            integer_create(0, 123), source_location_create(0, 0)))))),
             "(a: float, b: string) 123");
     }
 

--- a/tests/test_save_expression.c
+++ b/tests/test_save_expression.c
@@ -81,9 +81,10 @@ void test_save_expression(void)
                              expression_allocate(expression_from_identifier(identifier_expression_create(
                                  unicode_string_from_c_str("uint32"), source_location_create(0, 0)))));
         check_expression_rendering(
-            expression_from_lambda(lambda_create(parameters, 1, NULL, expression_allocate(
-                    expression_from_integer_literal(integer_literal_expression_create(
-                            integer_create(0, 1234), source_location_create(0, 0)))))),
+            expression_from_lambda(
+                lambda_create(parameters, 1, NULL,
+                              expression_allocate(expression_from_integer_literal(integer_literal_expression_create(
+                                  integer_create(0, 1234), source_location_create(0, 0)))))),
             "(a: uint32) 1234");
     }
 
@@ -216,8 +217,8 @@ void test_save_expression(void)
                                  unicode_string_from_c_str("uint32"), source_location_create(0, 0)))));
 
         check_expression_rendering(
-            expression_from_lambda(lambda_create(parameters, 1, NULL, expression_allocate(
-                    expression_from_loop(sequence_create(outer_loop, 2))))),
+            expression_from_lambda(lambda_create(
+                parameters, 1, NULL, expression_allocate(expression_from_loop(sequence_create(outer_loop, 2))))),
             "(a: uint32) loop\n"
             "    a == 123\n"
             "    loop\n"
@@ -236,9 +237,10 @@ void test_save_expression(void)
                                  unicode_string_from_c_str("string"), source_location_create(0, 0)))));
 
         check_expression_rendering(
-            expression_from_lambda(lambda_create(parameters, 2, NULL, expression_allocate(
-                    expression_from_integer_literal(integer_literal_expression_create(
-                            integer_create(0, 123), source_location_create(0, 0)))))),
+            expression_from_lambda(
+                lambda_create(parameters, 2, NULL,
+                              expression_allocate(expression_from_integer_literal(integer_literal_expression_create(
+                                  integer_create(0, 123), source_location_create(0, 0)))))),
             "(a: float, b: string) 123");
     }
 


### PR DESCRIPTION
**Before:** Functions could only have implicit return types.

**After:** Now all block functions can have an explicit return type. One line functions still can't have a return type as the syntax was rejected.

Fixes #23 